### PR TITLE
Adicion de servicio REST para consultar el ultimo intento de respuesta de un estudiante

### DIFF
--- a/activities/urls.py
+++ b/activities/urls.py
@@ -1,6 +1,6 @@
 from activities.views import *
 from django.urls import path
-from activities.views import CalificarAPI, MarcaApi
+from activities.views import CalificarAPI, MarcaApi, intentos_max
 app_name = 'activities'
 
 
@@ -11,4 +11,5 @@ urlpatterns = [
     path('preguntaOpcionMultiple/<int:marca>/', DetailPreguntaSeleccionMultiple.as_view()),
     path('calificacion', CalificarAPI.as_view(), name='calificacion'),
     path('marca', MarcaApi.as_view(), name='marca'),
+    path('ultimo_intento', intentos_max)
 ]

--- a/activities/views.py
+++ b/activities/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
 from rest_framework.response import Response
+from django.http import JsonResponse
 
 from activities.serializers import PreguntaSeleccionMultipleSerializer, CalificacionSerializer, RespuestaSeleccionMultipleSerializer, MarcaSerializer
 from activities.models import Calificacion, PreguntaOpcionMultiple, RespuestmultipleEstudiante, Opcionmultiple, Marca
@@ -111,3 +112,28 @@ class MarcaApi(ListModelMixin, GenericAPIView):
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, *kwargs)
+
+
+def intentos_max(request):
+    if request.method == 'GET':
+        pregunta = request.GET.get('id_pregunta')        
+        estudiante = request.GET.get('id_estudiante')        
+        opciones = Opcionmultiple.objects.filter(
+            preguntaSeleccionMultiple=pregunta)
+
+        respuestas = RespuestmultipleEstudiante.objects.filter(
+            estudiante=estudiante)
+        resps = []
+
+        for respuesta in respuestas:
+            for opcion in opciones:
+                if respuesta.respuestmultiple == opcion:
+                    print('ALGO')
+                    if respuesta.intento:
+                        resps.append(respuesta.intento)
+        if len(resps) > 0:
+            max_int = max(resps)
+        else: max_int = 0
+
+        print(max_int)
+        return JsonResponse({'ultimo_intento': max_int}, status=status.HTTP_200_OK)


### PR DESCRIPTION
Se crea un servicio para validar el último intento de respuesta de un estudiante a una pregunta
El endopint del servicio es: /activities/ultimo_intento?id_estudiante=X&id_pregunta=X

Ejemplo:
// 20191030002259
// BASE_URL/activities/ultimo_intento?id_estudiante=5&id_pregunta=1

{
"ultimo_intento": 2
}